### PR TITLE
Stop the error logs committing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+error_log.txt
+


### PR DESCRIPTION
Fix .gitignore to stop error_log.txt appearing in git commits.